### PR TITLE
Pytorcha and paraview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ ai = [
 "tf_keras==2.18.0 ; platform_system=='Darwin' and platform_machine=='arm64'",
 "tf_keras==2.16.0 ; platform_system=='Darwin' and platform_machine=='x86_64'",
 "tf_keras==2.18.0 ; platform_system != 'Darwin'",
+"torch", 
+"hydra_core",
+"einops",
+"timm",
 ]
 dev = ["black", "pre-commit", "pytest", "pytest-cov"]
 

--- a/settings_template.yaml
+++ b/settings_template.yaml
@@ -7,7 +7,6 @@
 # ========================================================================================
 # Startup folder
 start_folder: PATH
-# start_folder:
 # anon, reg, main
 workflow_mode: main
 # se, steam
@@ -29,7 +28,7 @@ registration_extra_debug: False
 registration: elastix_non_rigid
 # fast, slow
 registration_speed: fast
-# best, groupwise
+# first, best, groupwise
 registration_reference_method: best
 
 # ========================================================================================
@@ -48,6 +47,12 @@ remove_outliers_manually_pre: True
 # True, False
 # NOT WORKING WELL AT THE MOMENT
 remove_outliers_with_ai: False
+
+# ========================================================================================
+# DWIs NLM DENOISING
+# ========================================================================================
+# True, False
+image_denoising: False
 
 # ========================================================================================
 # MISC
@@ -84,7 +89,7 @@ u_net_segmentation: False
 n_ensemble: 5
 
 # ========================================================================================
-# TENSOR DENOISING
+# TENSOR DENOISING (EXPERIMENTAL)
 # ========================================================================================
 # True, False
 uformer_denoise: False

--- a/src/indi/extensions/extensions.py
+++ b/src/indi/extensions/extensions.py
@@ -136,7 +136,7 @@ def save_vtk_file(vectors: dict, tensors: dict, scalars: dict, info: dict, name:
             sg.point_data.get_array(counter).name = tensor_str
             sg.point_data.update()
             counter += 1
-    write_data(sg, os.path.join(folder_path, name + ".vtk"))
+    write_data(sg, os.path.join(folder_path, name))
 
 
 def export_vectors_tensors_vtk(dti, info: dict, settings: dict, mask_3c: NDArray, average_images: NDArray):

--- a/src/indi/extensions/image_denoising.py
+++ b/src/indi/extensions/image_denoising.py
@@ -1,0 +1,84 @@
+import numpy as np
+import os
+from skimage.restoration import denoise_nl_means, estimate_sigma
+import matplotlib.pyplot as plt
+import pandas as pd
+import logging
+
+
+def image_denoising(data: pd.DataFrame, logger: logging.Logger, settings: dict) -> pd.DataFrame:
+    """Denoise with an NLM filter all the DWIs in the dataframe.
+    The denoised images are saved in the original dataframe, replacing the original images.
+
+    Parameters
+    ----------
+    data : dataframe
+        table with images and all relevant information
+    logger : logger
+    settings : dict
+        dictionary with settings
+
+
+    Returns
+    -------
+    dataframe
+        table with denoised images
+    """
+
+    logger.debug("Image denoising with NLM")
+
+    # get a stack of all the DWIs
+    image_stack = np.stack(data["image"].values)
+
+    # denoise with a non-local means filter
+    denoise_image_stack = np.zeros(image_stack.shape)
+    # NLM parameters
+    patch_kw = dict(
+        patch_size=10,
+        patch_distance=20,
+        channel_axis=None,
+        preserve_range=True,
+    )
+
+    # denoise the images
+    for i in range(len(denoise_image_stack)):
+        sigma_est = estimate_sigma(image_stack[i], channel_axis=None)
+        denoise_image_stack[i] = denoise_nl_means(
+            image_stack[i], h=4 * sigma_est, sigma=sigma_est, fast_mode=False, **patch_kw
+        )
+
+    n_images = len(denoise_image_stack)
+    # save the denoised images in the original dataframe
+    df_temp = pd.DataFrame.from_records(denoise_image_stack[:, None])
+    data["image"] = df_temp
+
+    if settings["debug"]:
+        # display some examples of the original and denoised images
+        # get 5 random numbers between 0 and n_images
+        random_numbers = np.random.randint(0, n_images, 5)
+        # sort the random numbers
+        random_numbers.sort()
+
+        # display the images
+        fig, axes = plt.subplots(2, 5, figsize=(15, 5))
+        for i, ax in enumerate(axes.flat):
+            if i < 5:
+                ax.imshow(image_stack[random_numbers[i]], cmap="gray")
+                ax.set_title(f"Original {random_numbers[i]}")
+            else:
+                ax.imshow(denoise_image_stack[random_numbers[i - 5]], cmap="gray")
+                ax.set_title(f"Denoised {random_numbers[i - 5]}")
+            ax.axis("off")
+        plt.savefig(
+            os.path.join(
+                settings["debug_folder"],
+                "image_denoising_examples.png",
+            ),
+            dpi=200,
+            bbox_inches="tight",
+            pad_inches=0,
+            transparent=False,
+        )
+        plt.close()
+
+    return data

--- a/src/indi/extensions/uformer_tensor_denoising/uformer.py
+++ b/src/indi/extensions/uformer_tensor_denoising/uformer.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 from einops import rearrange, repeat
-from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+from timm.layers import DropPath, to_2tuple, trunc_normal_
 
 
 class ConvBlock(nn.Module):

--- a/src/indi/extensions/uformer_tensor_denoising/uformer_tensor_denoising.py
+++ b/src/indi/extensions/uformer_tensor_denoising/uformer_tensor_denoising.py
@@ -5,10 +5,14 @@ import torch
 
 from indi.extensions.uformer_tensor_denoising.utils import IndependentEnsemble
 
+# need to have the line below, otherwise I get a python error:
+# /opt/homebrew/Cellar/python@3.11/3.11.12/Frameworks/Python.framework/Versions/3.11/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up
+torch.set_num_threads(1)
+
 MODELS = {
-    (1, "1BH", "BH1"): "/usr/local/dtcmr/pytorch_tensor_denoising/state_dict_1bh.pth",
-    (3, "3BH", "BH3"): "/usr/local/dtcmr/pytorch_tensor_denoising/state_dict_3bh.pth",
-    (5, "5BH", "BH5"): "/usr/local/dtcmr/pytorch_tensor_denoising/state_dict_5bh.pth",
+    (1, "1BH", "BH1"): "/usr/local/dtcmr/transformer_tensor_denoising/state_dict_1bh.pth",
+    (3, "3BH", "BH3"): "/usr/local/dtcmr/transformer_tensor_denoising/state_dict_3bh.pth",
+    (5, "5BH", "BH5"): "/usr/local/dtcmr/transformer_tensor_denoising/state_dict_5bh.pth",
 }
 
 SHIFT = torch.tensor(
@@ -41,7 +45,7 @@ MODEL_CONFIG = {
         "image_size": 128,
         "initial_channels": 16,
         "_convert_": "all",
-        "_target_": "extensions.uformer_tensor_denoising.discriminator.DiscriminatorForVGG",
+        "_target_": "indi.extensions.uformer_tensor_denoising.discriminator.DiscriminatorForVGG",
     },
     "generator": {
         "img_size": 128,
@@ -63,10 +67,10 @@ MODEL_CONFIG = {
         "token_mlp": "leff",
         "se_layer": False,
         "_convert_": "all",
-        "_target_": "extensions.uformer_tensor_denoising.uformer.Uformer",
+        "_target_": "indi.extensions.uformer_tensor_denoising.uformer.Uformer",
     },
     "_convert_": "all",
-    "_target_": "extensions.uformer_tensor_denoising.gan_wrapper.GANUFormerModelWrapper",
+    "_target_": "indi.extensions.uformer_tensor_denoising.gan_wrapper.GANUFormerModelWrapper",
 }
 
 

--- a/src/indi/scripts/main.py
+++ b/src/indi/scripts/main.py
@@ -30,6 +30,7 @@ from indi.extensions.get_eigensystem import get_eigensystem
 from indi.extensions.get_fa_md import get_fa_md
 from indi.extensions.get_tensor_orientation_maps import get_tensor_orientation_maps
 from indi.extensions.heart_segmentation import get_average_images, heart_segmentation
+from indi.extensions.image_denoising import image_denoising
 from indi.extensions.image_registration import image_registration
 from indi.extensions.initial_setup import initial_setup
 from indi.extensions.phase_correction_for_complex_averaging import phase_correction_for_complex_averaging
@@ -108,6 +109,12 @@ def main():
         # =========================================================
         if settings["complex_data"]:
             data = phase_correction_for_complex_averaging(data, logger, settings)
+
+        # =========================================================
+        # NLM image denoising of all DWIs
+        # =========================================================
+        if settings["image_denoising"]:
+            data = image_denoising(data, logger, settings)
 
         # =========================================================
         # DWIs registration


### PR DESCRIPTION
There are a few related but different things in this PR:
- added some modules required by the pytorch tensor denoising functions
- added a simple NLM denoising option for all DWIs (to compare with pytorch)
- removed the vtk extension when exporting paraview files, so that they are exported in a more modern xml format
- added option to use the first b0 as the reference to the registration (instead of the brightest b0 image). This way we can do comparisons with different number of repetitions, using the same segmentation.